### PR TITLE
remove usage of deprecated `refAllDeclsRecursive` and `intToEnum`

### DIFF
--- a/src/Reader.zig
+++ b/src/Reader.zig
@@ -97,7 +97,8 @@ pub fn Reader(comptime limits: ReadLimits) type {
 
             // Decode the tag
             const decoded_tag = common.decodeTag(tag_byte);
-            const val_type = try std.meta.intToEnum(std.meta.Tag(common.Value), decoded_tag.tag);
+            const val_type = std.enums.fromInt(std.meta.Tag(common.Value), decoded_tag.tag) orelse
+                return error.InvalidEnumTag;
 
             switch (val_type) {
                 .containerEnd => {
@@ -258,7 +259,8 @@ pub fn Reader(comptime limits: ReadLimits) type {
             if (self.pos >= self.bytes.len) return error.UnexpectedEof;
             const tag_byte = self.bytes[self.pos];
             const decoded = common.decodeTag(tag_byte);
-            const tag = try std.meta.intToEnum(std.meta.Tag(common.Value), decoded.tag);
+            const tag = std.enums.fromInt(std.meta.Tag(common.Value), decoded.tag) orelse
+                return error.InvalidEnumTag;
             return .{ .tag = tag, .data = decoded.data };
         }
 
@@ -296,7 +298,7 @@ pub fn Reader(comptime limits: ReadLimits) type {
             if (self.pos >= self.bytes.len) return error.UnexpectedEof;
             const elem_byte = self.bytes[self.pos];
             self.pos += 1;
-            const elem = try std.meta.intToEnum(common.TypedArrayElem, elem_byte);
+            const elem = std.enums.fromInt(common.TypedArrayElem, elem_byte) orelse return error.InvalidEnumTag;
 
             const count_len: usize = @as(usize, tag_data) + 1;
             if (count_len > self.bytes.len - self.pos) return error.UnexpectedEof;
@@ -369,7 +371,8 @@ pub fn Reader(comptime limits: ReadLimits) type {
             self.pos += 1;
 
             const decoded = common.decodeTag(tag_byte);
-            const val_type = try std.meta.intToEnum(std.meta.Tag(common.Value), decoded.tag);
+            const val_type = std.enums.fromInt(std.meta.Tag(common.Value), decoded.tag) orelse
+                return error.InvalidEnumTag;
 
             switch (val_type) {
                 .array, .object => {
@@ -385,7 +388,8 @@ pub fn Reader(comptime limits: ReadLimits) type {
                         self.pos += 1;
 
                         const inner_decoded = common.decodeTag(inner_tag);
-                        const inner_type = try std.meta.intToEnum(std.meta.Tag(common.Value), inner_decoded.tag);
+                        const inner_type = std.enums.fromInt(std.meta.Tag(common.Value), inner_decoded.tag) orelse
+                            return error.InvalidEnumTag;
 
                         const ev = try skipOneValue(self, inner_decoded, inner_type);
                         switch (ev) {
@@ -414,7 +418,8 @@ pub fn Reader(comptime limits: ReadLimits) type {
             self.pos += 1;
 
             const decoded = common.decodeTag(tag_byte);
-            const val_type = try std.meta.intToEnum(std.meta.Tag(common.Value), decoded.tag);
+            const val_type = std.enums.fromInt(std.meta.Tag(common.Value), decoded.tag) orelse
+                return error.InvalidEnumTag;
 
             if (val_type != .varIntBytes and val_type != .bytes and val_type != .smallBytes) {
                 return error.InvalidEnumTag;
@@ -532,11 +537,11 @@ pub fn Reader(comptime limits: ReadLimits) type {
 
             const root_peek = try self.peekTag();
 
-                if (root_peek.tag != .object and root_peek.tag != .array) {
-                    if (remaining > 0) {
-                        var has_empty = false;
-                        for (queries) |q| {
-                            if (!q.resolved and q.path.len == 0) {
+            if (root_peek.tag != .object and root_peek.tag != .array) {
+                if (remaining > 0) {
+                    var has_empty = false;
+                    for (queries) |q| {
+                        if (!q.resolved and q.path.len == 0) {
                             has_empty = true;
                             break;
                         }
@@ -551,8 +556,8 @@ pub fn Reader(comptime limits: ReadLimits) type {
                                 remaining -= 1;
                             }
                         }
-                        }
                     }
+                }
 
                 if (queries.len > 1) {
                     const LessIdx = struct {
@@ -878,20 +883,20 @@ pub fn Reader(comptime limits: ReadLimits) type {
             const off = index * elem_size;
             const chunk = ta.bytes[off..][0..elem_size];
 
-	            return switch (ta.elem) {
-	                .u8 => .{ .u8 = chunk[0] },
-	                .i8 => .{ .i8 = @bitCast(chunk[0]) },
-	                .u16 => .{ .u16 = std.mem.readInt(u16, chunk[0..2], .little) },
-	                .i16 => .{ .i16 = std.mem.readInt(i16, chunk[0..2], .little) },
-	                .u32 => .{ .u32 = std.mem.readInt(u32, chunk[0..4], .little) },
-	                .i32 => .{ .i32 = std.mem.readInt(i32, chunk[0..4], .little) },
-	                .u64 => .{ .u64 = std.mem.readInt(u64, chunk[0..8], .little) },
-	                .i64 => .{ .i64 = std.mem.readInt(i64, chunk[0..8], .little) },
-	                .f32 => .{ .f32 = @bitCast(std.mem.readInt(u32, chunk[0..4], .little)) },
-	                .f64 => .{ .f64 = @bitCast(std.mem.readInt(u64, chunk[0..8], .little)) },
-	                .f16 => .{ .f16 = @bitCast(std.mem.readInt(u16, chunk[0..2], .little)) },
-	            };
-	        }
+            return switch (ta.elem) {
+                .u8 => .{ .u8 = chunk[0] },
+                .i8 => .{ .i8 = @bitCast(chunk[0]) },
+                .u16 => .{ .u16 = std.mem.readInt(u16, chunk[0..2], .little) },
+                .i16 => .{ .i16 = std.mem.readInt(i16, chunk[0..2], .little) },
+                .u32 => .{ .u32 = std.mem.readInt(u32, chunk[0..4], .little) },
+                .i32 => .{ .i32 = std.mem.readInt(i32, chunk[0..4], .little) },
+                .u64 => .{ .u64 = std.mem.readInt(u64, chunk[0..8], .little) },
+                .i64 => .{ .i64 = std.mem.readInt(i64, chunk[0..8], .little) },
+                .f32 => .{ .f32 = @bitCast(std.mem.readInt(u32, chunk[0..4], .little)) },
+                .f64 => .{ .f64 = @bitCast(std.mem.readInt(u64, chunk[0..8], .little)) },
+                .f16 => .{ .f16 = @bitCast(std.mem.readInt(u16, chunk[0..2], .little)) },
+            };
+        }
 
         /// Reads a value at a given path. Path format: "key", "key.nested", "array[0]", "obj.arr[2].name"
         /// Returns null if the path doesn't exist or points to an incompatible type.

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -1,6 +1,9 @@
+const std = @import("std");
+
 pub const Writer = @import("Writer.zig");
 pub const Update = Writer.Update;
-pub const ApplyUpdatesError = @import("updates.zig").Error;
+const updates = @import("updates.zig");
+pub const ApplyUpdatesError = updates.Error;
 
 const reader_mod = @import("Reader.zig");
 pub const Reader = reader_mod.Reader;
@@ -16,3 +19,12 @@ pub const InspectError = inspect_mod.Error;
 
 pub const Common = @import("common.zig");
 pub const Value = Common.Value;
+
+test {
+    std.testing.refAllDecls(@This());
+    std.testing.refAllDecls(Writer);
+    std.testing.refAllDecls(updates);
+    std.testing.refAllDecls(reader_mod);
+    std.testing.refAllDecls(inspect_mod);
+    std.testing.refAllDecls(Common);
+}

--- a/src/updates.zig
+++ b/src/updates.zig
@@ -22,7 +22,7 @@ const ReadError = reader_mod.Error;
 fn peekTagType(reader: anytype, buf: []const u8) ReadError!std.meta.Tag(common.Value) {
     if (reader.pos >= buf.len) return ReadError.UnexpectedEof;
     const decoded = common.decodeTag(buf[reader.pos]);
-    return std.meta.intToEnum(std.meta.Tag(common.Value), decoded.tag);
+    return std.enums.fromInt(std.meta.Tag(common.Value), decoded.tag) orelse error.InvalidEnumTag;
 }
 
 fn decodeUpdateValue(comptime WriterT: type, upd: anytype) (WriterT.Error || ReadError)!common.Value {

--- a/test/main.zig
+++ b/test/main.zig
@@ -15,7 +15,9 @@ var shared_encoded: [1024]u8 = undefined;
 var shared_encoded_len: usize = 0;
 
 test {
-    std.testing.refAllDeclsRecursive(@This());
+    std.testing.refAllDecls(@This());
+    std.testing.refAllDecls(bufzilla);
+    std.testing.refAllDecls(encodingTests);
 }
 
 // =============================================================================
@@ -1039,7 +1041,8 @@ test "writer/reader: smallUint encodes 0..7" {
     try std.testing.expectEqual(@as(usize, 1), written.len);
 
     const decoded = Common.decodeTag(written[0]);
-    const tag = try std.meta.intToEnum(std.meta.Tag(Value), decoded.tag);
+    const tag = std.enums.fromInt(std.meta.Tag(Value), decoded.tag) orelse
+        return error.InvalidEnumTag;
     try std.testing.expectEqual(std.meta.Tag(Value).smallUint, tag);
     try std.testing.expectEqual(@as(u3, 7), decoded.data);
 


### PR DESCRIPTION
Both were removed in Zig 0.16, `std.meta.intToEnum` was already marked as deprecated in 0.15. Unit tests now pass on both versions.